### PR TITLE
feat(categories): Implementar API CRUD para categorías (Closes #34)

### DIFF
--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from 'next/server';
+import { categoryDb } from '@/app/lib/db';
+
+// Expresión regular para validar un UUID
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Definimos la forma del objeto de contexto que Next.js pasa a la ruta
+interface RouteContext {
+  params: { id: string };
+}
+
+// GET /api/categories/:id - Obtener una categoría por ID
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const id = context.params.id;
+
+    if (!UUID_REGEX.test(id)) {
+      return NextResponse.json({ message: 'El ID proporcionado no es un UUID válido.' }, { status: 400 });
+    }
+
+    const category = categoryDb.getCategoryById(id);
+
+    if (!category) {
+      return NextResponse.json({ message: `Categoría con ID "${id}" no encontrada.` }, { status: 404 });
+    }
+
+    return NextResponse.json(category, { status: 200 });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Error desconocido';
+    console.error(`Error fetching category:`, errorMessage);
+    return NextResponse.json({ message: 'Error interno del servidor' }, { status: 500 });
+  }
+}
+
+// PUT /api/categories/:id - Actualizar una categoría
+export async function PUT(request: Request, context: RouteContext) {
+  try {
+    const id = context.params.id;
+    const body = await request.json();
+    const { nombre, descripcion, activa } = body;
+
+    if (!UUID_REGEX.test(id)) {
+      return NextResponse.json({ message: 'El ID proporcionado no es un UUID válido.' }, { status: 400 });
+    }
+
+    if (nombre === undefined && descripcion === undefined && activa === undefined) {
+      return NextResponse.json({ message: 'Se requiere al menos un campo (nombre, descripcion, activa) para actualizar.' }, { status: 400 });
+    }
+
+    if (typeof nombre === 'string' && categoryDb.nameExists(nombre, id)) {
+      return NextResponse.json({ message: `La categoría "${nombre}" ya existe.` }, { status: 409 });
+    }
+
+    const updatedCategory = categoryDb.updateCategory(id, {
+      ...(nombre !== undefined && { nombre: String(nombre).trim() }),
+      ...(descripcion !== undefined && { descripcion: String(descripcion).trim() }),
+      ...(activa !== undefined && { activa: Boolean(activa) }),
+    });
+
+    if (!updatedCategory) {
+      return NextResponse.json({ message: `Categoría con ID "${id}" no encontrada.` }, { status: 404 });
+    }
+
+    return NextResponse.json(updatedCategory, { status: 200 });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ message: 'Cuerpo de la solicitud JSON mal formado.' }, { status: 400 });
+    }
+    const errorMessage = error instanceof Error ? error.message : 'Error desconocido';
+    console.error(`Error updating category:`, errorMessage);
+    return NextResponse.json({ message: 'Error interno del servidor' }, { status: 500 });
+  }
+}
+
+// DELETE /api/categories/:id - Eliminar una categoría
+export async function DELETE(request: Request, context: RouteContext) {
+  try {
+    const id = context.params.id;
+
+    if (!UUID_REGEX.test(id)) {
+      return NextResponse.json({ message: 'El ID proporcionado no es un UUID válido.' }, { status: 400 });
+    }
+
+    const success = categoryDb.deleteCategory(id);
+
+    if (!success) {
+      return NextResponse.json({ message: `Categoría con ID "${id}" no encontrada.` }, { status: 404 });
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Error desconocido';
+    console.error(`Error deleting category:`, errorMessage);
+    return NextResponse.json({ message: 'Error interno del servidor' }, { status: 500 });
+  }
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,61 @@
+
+import { NextResponse } from 'next/server';
+import { categoryDb } from '@/app/lib/db';
+
+// GET /api/categories - Listar todas las categorías
+export async function GET() {
+  try {
+    const categories = categoryDb.getAllCategories();
+    return NextResponse.json(categories, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching categories:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/categories - Crear una nueva categoría
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { nombre, descripcion, activa } = body;
+
+    // 1. Validar datos de entrada
+    if (typeof nombre !== 'string' || nombre.trim() === '' || typeof descripcion !== 'string' || typeof activa !== 'boolean') {
+      return NextResponse.json(
+        { message: 'Datos de entrada inválidos. Se requiere nombre (string), descripcion (string) y activa (boolean).' },
+        { status: 400 }
+      );
+    }
+
+    // 2. Validar que el nombre no exista (case-insensitive)
+    if (categoryDb.nameExists(nombre)) {
+      return NextResponse.json(
+        { message: `La categoría "${nombre}" ya existe.` },
+        { status: 409 } // 409 Conflict
+      );
+    }
+
+    // 3. Crear la categoría
+    const newCategory = categoryDb.createCategory({
+      nombre: nombre.trim(),
+      descripcion: descripcion.trim(),
+      activa,
+    });
+
+    return NextResponse.json(newCategory, { status: 201 });
+  } catch (error) {
+    // Manejo de errores de parsing de JSON o errores inesperados
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ message: 'Cuerpo de la solicitud JSON mal formado.' }, { status: 400 });
+    }
+    
+    console.error('Error creating category:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Este commit implementa la API REST completa para el recurso de categorías, incluyendo los endpoints para crear, leer, actualizar y eliminar (CRUD). Se añade el manejo de errores, validaciones de datos (UUIDs, nombres únicos) y tests actualizados para cubrir la nueva funcionalidad.

Resuelve #<ID>

## Resumen
- Qué hace este cambio y para qué.

## Cómo probar
```bash
<pegar comandos curl>
```

## Resultados esperados
- [ ] Status HTTP correcto
- [ ] Respuesta JSON con campos esperados

## Checklist
- [ ] Referencié el issue con #ID
- [ ] Agregué pruebas manuales (curl)
- [ ] Recibí al menos 1 review
- [ ] El código sigue las convenciones del proyecto
- [ ] Los endpoints manejan errores apropiadamente (400, 404, 409, 500)

## Evidencia
- [ ] Capturas de pantalla de las pruebas curl
- [ ] Logs de la consola (si aplica)
